### PR TITLE
Create Toggle Keybind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(csgo_external)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=c++11 -lX11")
 
 set(EXECUTABLE_OUTPUT_PATH ./build)
 

--- a/main.cpp
+++ b/main.cpp
@@ -158,7 +158,7 @@ int main() {
 		if (shouldGlow)
 	        hack::Glow(&csgo, &client, addressOfGlowPointer);
 
-        usleep(5000);
+        usleep(1000);
     }
 
 //    cout << "Game ended." << endl;

--- a/main.cpp
+++ b/main.cpp
@@ -1,10 +1,14 @@
 #include <iostream>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
 #include "log.hpp"
 #include "remote.hpp"
 #include "hack.hpp"
 #include "netvar.hpp"
 
 using namespace std;
+
+bool shouldGlow = true;
 
 // This isn't called or used because it's for debugging, use it if you want.
 void printAllClasses() {
@@ -29,6 +33,17 @@ int main() {
     log::init();
     log::put("Hack loaded...");
 
+	Display* dpy = XOpenDisplay(0);
+	Window root = DefaultRootWindow(dpy);
+	XEvent ev;
+
+	int keycode = XKeysymToKeycode(dpy, XK_X);
+	unsigned int modifiers = ControlMask | ShiftMask;
+
+	XGrabKey(dpy, keycode, modifiers, root, false,
+				GrabModeAsync, GrabModeAsync);
+	XSelectInput(dpy, root, KeyPressMask);
+	
     remote::Handle csgo;
 
     while (true) {
@@ -123,7 +138,25 @@ int main() {
     cout << "Cached " << std::dec << netvar::GetAllClasses().size() << " networked classes" << endl;
 
     while (csgo.IsRunning()) {
-        hack::Glow(&csgo, &client, addressOfGlowPointer);
+		while (XPending(dpy) > 0) {
+			XNextEvent(dpy, &ev);
+			switch (ev.type) {
+				case KeyPress:
+					cout << "Toggling glow..." << endl;
+					XUngrabKey(dpy, keycode, modifiers, root);
+					shouldGlow = !shouldGlow;
+					break;
+				default:
+					break;
+			}
+
+			XGrabKey(dpy, keycode, modifiers, root, false,
+						GrabModeAsync, GrabModeAsync);
+			XSelectInput(dpy, root, KeyPressMask);
+		}
+
+		if (shouldGlow)
+	        hack::Glow(&csgo, &client, addressOfGlowPointer);
 
         usleep(5000);
     }


### PR DESCRIPTION
# Create Toggle Keybind
## Synopsis
- Solves #2 
  - (Kind of)
  - No toggle for just radar.
- Press a keybind to toggle the cheat.
## Notes
- Requires Xlib, `# apt-get libx11-dev` on Debian based systems
- Bind in this Pull Request is Ctrl+Shift+X, but this is not optimal for gameplay.
## Known Bugs
- Does not work with Numlock enabled.
