### PR TITLE
Fixed cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(csgo_external)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=c++11 -lX11")
-
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m32 -std=c++11")
 set(EXECUTABLE_OUTPUT_PATH ./build)
 
 set(SOURCE_FILES log.cpp remote.cpp netvar.cpp hack.cpp main.cpp)
 add_executable(csgo_external ${SOURCE_FILES})
+target_link_libraries(csgo_external "-lX11")


### PR DESCRIPTION
-lX11 is not cflag(compile flag), it's a link flag. So this flag needs to be in link flags rather than cflags. https://cmake.org/cmake/help/v3.0/command/target_link_libraries.html

Above page describe about how to set link flags.
